### PR TITLE
Integrate import folder functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,21 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import LandingPage from './LandingPage';
-import Quiz from './Quiz';
-import Summary from './Summary';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
+import LandingPage from './LandingPage'
+import Quiz from './Quiz'
+import Summary from './Summary'
+import RisksSummary from './RisksSummary'
 
-export default function App() {
+function App() {
   return (
-    <BrowserRouter>
+    <Router>
       <Routes>
         <Route path="/" element={<LandingPage />} />
         <Route path="/quiz" element={<Quiz />} />
         <Route path="/summary" element={<Summary />} />
+        <Route path="/risks" element={<RisksSummary />} />
+        <Route path="*" element={<Navigate to="/" />} />
       </Routes>
-    </BrowserRouter>
-  );
+    </Router>
+  )
 }
+
+export default App

--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -1,5 +1,53 @@
-export default function LandingPage() {
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+function LandingPage() {
+  const [email, setEmail] = useState('')
+  const navigate = useNavigate()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    // Store email if needed
+    localStorage.setItem('userEmail', email)
+    // Navigate to quiz page
+    navigate('/quiz')
+  }
+
   return (
-    <div className="bg-blue-500 text-white p-4">Landing Page</div>
-  );
+    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
+      <main className="max-w-md w-full">
+        <div className="text-center mb-12">
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
+            Worried your next deal's IT/ops risk is hidden?
+          </h1>
+          <p className="text-xl text-gray-700 mb-8">
+            Get a 1-page execution risk snapshot<br />in under 5 minutes.
+          </p>
+        </div>
+        
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="Enter your email"
+              required
+              className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+          <div>
+            <button
+              type="submit"
+              className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-4 rounded-md transition duration-200"
+            >
+              Continue
+            </button>
+          </div>
+        </form>
+      </main>
+    </div>
+  )
 }
+
+export default LandingPage

--- a/src/Quiz.tsx
+++ b/src/Quiz.tsx
@@ -1,5 +1,159 @@
-export default function Quiz() {
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+function Quiz() {
+  const [urgency, setUrgency] = useState(3)
+  const [area, setArea] = useState('')
+  const [canPay, setCanPay] = useState(false)
+  const navigate = useNavigate()
+  
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    // Store the quiz answers in localStorage to retrieve on risks summary page
+    localStorage.setItem('quizAnswers', JSON.stringify({
+      urgency,
+      area,
+      canPay
+    }))
+    // Navigate to risks summary page
+    navigate('/risks')
+  }
+
   return (
-    <div className="bg-blue-500 text-white p-4">Quiz</div>
-  );
+    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
+      <main className="max-w-md w-full">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-4">
+            IT/Ops Risk Assessment
+          </h1>
+          <p className="text-lg text-gray-700">
+            Please answer these questions to help us understand your needs.
+          </p>
+        </div>
+        
+        <form onSubmit={handleSubmit} className="space-y-8">
+          {/* Question 1: Urgency Slider */}
+          <div className="space-y-3">
+            <label className="block text-lg font-medium text-gray-900">
+              How urgent is your integration risk?
+            </label>
+            <div className="flex items-center space-x-2">
+              <span className="text-sm text-gray-500">Low</span>
+              <input
+                type="range"
+                min="1"
+                max="5"
+                value={urgency}
+                onChange={(e) => setUrgency(parseInt(e.target.value))}
+                className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+              />
+              <span className="text-sm text-gray-500">High</span>
+            </div>
+            <div className="text-center text-lg font-medium">
+              {urgency}
+            </div>
+          </div>
+          
+          {/* Question 2: Area Radio Buttons */}
+          <div className="space-y-3">
+            <label className="block text-lg font-medium text-gray-900">
+              Which area worries you most?
+            </label>
+            <div className="space-y-2">
+              <div className="flex items-center">
+                <input
+                  type="radio"
+                  id="cybersecurity"
+                  name="area"
+                  value="Cybersecurity"
+                  checked={area === 'Cybersecurity'}
+                  onChange={(e) => setArea(e.target.value)}
+                  className="h-4 w-4 text-blue-600 focus:ring-blue-500"
+                />
+                <label htmlFor="cybersecurity" className="ml-2 text-gray-700">
+                  Cybersecurity
+                </label>
+              </div>
+              <div className="flex items-center">
+                <input
+                  type="radio"
+                  id="erp"
+                  name="area"
+                  value="ERP integration"
+                  checked={area === 'ERP integration'}
+                  onChange={(e) => setArea(e.target.value)}
+                  className="h-4 w-4 text-blue-600 focus:ring-blue-500"
+                />
+                <label htmlFor="erp" className="ml-2 text-gray-700">
+                  ERP integration
+                </label>
+              </div>
+              <div className="flex items-center">
+                <input
+                  type="radio"
+                  id="supply"
+                  name="area"
+                  value="Supply chain"
+                  checked={area === 'Supply chain'}
+                  onChange={(e) => setArea(e.target.value)}
+                  className="h-4 w-4 text-blue-600 focus:ring-blue-500"
+                />
+                <label htmlFor="supply" className="ml-2 text-gray-700">
+                  Supply chain
+                </label>
+              </div>
+            </div>
+          </div>
+          
+          {/* Question 3: Yes/No Toggle */}
+          <div className="space-y-3">
+            <label className="block text-lg font-medium text-gray-900">
+              Can you pay up to $5K for a quick risk check?
+            </label>
+            <div className="flex items-center space-x-4">
+              <button
+                type="button"
+                onClick={() => setCanPay(false)}
+                className={`px-4 py-2 rounded-md ${
+                  !canPay 
+                    ? 'bg-blue-600 text-white' 
+                    : 'bg-gray-200 text-gray-700'
+                }`}
+              >
+                No
+              </button>
+              <button
+                type="button"
+                onClick={() => setCanPay(true)}
+                className={`px-4 py-2 rounded-md ${
+                  canPay 
+                    ? 'bg-blue-600 text-white' 
+                    : 'bg-gray-200 text-gray-700'
+                }`}
+              >
+                Yes
+              </button>
+            </div>
+          </div>
+          
+          {/* Submit Button */}
+          <div className="pt-4">
+            <button
+              type="submit"
+              disabled={!area}
+              className={`w-full py-3 px-4 rounded-md transition duration-200 ${
+                area 
+                  ? 'bg-blue-600 hover:bg-blue-700 text-white font-medium' 
+                  : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+              }`}
+            >
+              Submit
+            </button>
+          </div>
+        </form>
+      </main>
+    </div>
+  )
 }
+
+export default Quiz

--- a/src/RisksSummary.tsx
+++ b/src/RisksSummary.tsx
@@ -1,0 +1,107 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+function RisksSummary() {
+  const [answers, setAnswers] = useState<{
+    urgency: number;
+    area: string;
+    canPay: boolean;
+  } | null>(null)
+  const navigate = useNavigate()
+  
+  useEffect(() => {
+    // Retrieve quiz answers from localStorage
+    const storedAnswers = localStorage.getItem('quizAnswers')
+    if (storedAnswers) {
+      setAnswers(JSON.parse(storedAnswers))
+    }
+  }, [])
+  
+  // Function to determine top risks based on quiz answers
+  const getTopRisks = () => {
+    if (!answers) return ['No data available', 'No data available']
+    
+    const risks = []
+    
+    // Risk based on area of concern
+    switch(answers.area) {
+      case 'Cybersecurity':
+        risks.push('Data breach vulnerability in legacy systems')
+        break
+      case 'ERP integration':
+        risks.push('System incompatibility causing data synchronization failures')
+        break
+      case 'Supply chain':
+        risks.push('Vendor management gaps creating operational bottlenecks')
+        break
+      default:
+        risks.push('Undefined operational risk area')
+    }
+    
+    // Risk based on urgency level
+    if (answers.urgency >= 4) {
+      risks.push('Critical timeline pressure increasing implementation errors')
+    } else if (answers.urgency >= 2) {
+      risks.push('Resource allocation inefficiencies')
+    } else {
+      risks.push('Stakeholder alignment challenges')
+    }
+    
+    return risks
+  }
+  
+  const handleGetFullReport = () => {
+    // Navigate back to landing page for email capture
+    navigate('/')
+  }
+
+  if (!answers) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
+        <p>Loading your results...</p>
+      </div>
+    )
+  }
+  
+  const topRisks = getTopRisks()
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
+      <main className="max-w-md w-full">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-6">
+            Your Top 2 Execution Risks
+          </h1>
+        </div>
+        
+        <div className="bg-gray-50 p-6 rounded-lg shadow-sm mb-8">
+          <ul className="list-disc pl-5 space-y-4">
+            <li className="text-gray-800 text-lg">
+              <span className="font-medium">Risk #1:</span> {topRisks[0]}
+            </li>
+            <li className="text-gray-800 text-lg">
+              <span className="font-medium">Risk #2:</span> {topRisks[1]}
+            </li>
+          </ul>
+        </div>
+        
+        <div className="text-center mb-8">
+          <p className="text-lg text-gray-700">
+            This is just a preview of your execution risks. Get our comprehensive analysis to identify all potential issues.
+          </p>
+        </div>
+        
+        <div className="flex justify-center">
+          <button
+            onClick={handleGetFullReport}
+            className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition duration-200"
+          >
+            Get Full Report by Email
+          </button>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+export default RisksSummary

--- a/src/Summary.tsx
+++ b/src/Summary.tsx
@@ -1,5 +1,101 @@
-export default function Summary() {
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+function Summary() {
+  const [answers, setAnswers] = useState<{
+    urgency: number;
+    area: string;
+    canPay: boolean;
+  } | null>(null)
+  const navigate = useNavigate()
+  
+  useEffect(() => {
+    // Retrieve quiz answers from localStorage
+    const storedAnswers = localStorage.getItem('quizAnswers')
+    if (storedAnswers) {
+      setAnswers(JSON.parse(storedAnswers))
+    }
+  }, [])
+  
+  const getUrgencyText = (urgency: number) => {
+    switch(urgency) {
+      case 1: return 'Very Low';
+      case 2: return 'Low';
+      case 3: return 'Medium';
+      case 4: return 'High';
+      case 5: return 'Very High';
+      default: return 'Medium';
+    }
+  }
+  
+  const handleStartOver = () => {
+    // Clear stored answers and return to landing page
+    localStorage.removeItem('quizAnswers')
+    navigate('/')
+  }
+
+  if (!answers) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
+        <p>Loading your results...</p>
+      </div>
+    )
+  }
+
   return (
-    <div className="bg-blue-500 text-white p-4">Summary</div>
-  );
+    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
+      <main className="max-w-md w-full">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-4">
+            Your Risk Assessment Summary
+          </h1>
+          <p className="text-lg text-gray-700">
+            Based on your responses, here's what we know about your situation:
+          </p>
+        </div>
+        
+        <div className="bg-gray-50 p-6 rounded-lg shadow-sm space-y-4 mb-8">
+          <div>
+            <h2 className="text-lg font-medium text-gray-900">Risk Urgency</h2>
+            <p className="text-gray-700">
+              Your integration risk urgency is <span className="font-medium">{getUrgencyText(answers.urgency)} ({answers.urgency}/5)</span>
+            </p>
+          </div>
+          
+          <div>
+            <h2 className="text-lg font-medium text-gray-900">Area of Concern</h2>
+            <p className="text-gray-700">
+              Your primary concern is <span className="font-medium">{answers.area}</span>
+            </p>
+          </div>
+          
+          <div>
+            <h2 className="text-lg font-medium text-gray-900">Budget Availability</h2>
+            <p className="text-gray-700">
+              {answers.canPay 
+                ? 'You are willing to invest up to $5K for a quick risk check.'
+                : 'You are not currently able to invest $5K for a quick risk check.'}
+            </p>
+          </div>
+        </div>
+        
+        <div className="text-center mb-8">
+          <p className="text-lg text-gray-700">
+            Thank you for completing this assessment. Our team will be in touch with you shortly to discuss next steps.
+          </p>
+        </div>
+        
+        <div className="flex justify-center">
+          <button
+            onClick={handleStartOver}
+            className="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition duration-200"
+          >
+            Start Over
+          </button>
+        </div>
+      </main>
+    </div>
+  )
 }
+
+export default Summary

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,40 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  
+  color-scheme: light;
+  color: #213547;
+  background-color: #ffffff;
+  
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  place-items: center;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+#root {
+  width: 100%;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  #root {
+    padding: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- port landing page, quiz, and results screens into `src`
- add risk summary route and component
- share global styles across the new pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843909de108832a9894c7089f1e9a35