### PR TITLE
Add API protections with rate limit and hCaptcha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "temp-project",
       "version": "0.0.0",
       "dependencies": {
+        "@upstash/ratelimit": "^1.2.0",
+        "@upstash/redis": "^1.5.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2"
@@ -1737,6 +1739,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.9.tgz",
+      "integrity": "sha512-9NXXxZ5y1/A/zqKLlVT7NsAWSggJfOjB0hG6Ffx29b4jbzHOiQVWB55h5+j2clT9Ib+mNPXn0iB5zN3aWLkICw==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-1.2.1.tgz",
+      "integrity": "sha512-o01lV1yFS5Fzj5KONZmNyVch/Qrlj785B2ob+kStUmxn8F6xXk7IHTQqVcHE+Ce3CmT/qQIwvMxDZftyJ5wYpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.9"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.0.tgz",
+      "integrity": "sha512-WUm0Jz1xN4DBDGeJIi2Y0kVsolWRB2tsVds4SExaiLg4wBdHFMB+8IfZtBWr+BP0FvhuBr5G1/VLrJ9xzIWHsg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -4438,6 +4470,12 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@upstash/ratelimit": "^1.2.0",
+    "@upstash/redis": "^1.5.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2"

--- a/pages/api/submit.ts
+++ b/pages/api/submit.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
+
+const redis = Redis.fromEnv();
+
+const ratelimit = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(3, '1 h'),
+});
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const ip = (Array.isArray(req.headers['x-forwarded-for']) ? req.headers['x-forwarded-for'][0] : req.headers['x-forwarded-for'])
+    || req.socket.remoteAddress
+    || 'unknown';
+
+  const { success } = await ratelimit.limit(ip as string);
+  if (!success) {
+    return res.status(429).json({ error: 'Too many requests' });
+  }
+
+  const token = req.body?.hcaptchaToken;
+  if (!token) {
+    return res.status(400).json({ error: 'Missing hCaptcha token' });
+  }
+
+  const verify = await fetch('https://hcaptcha.com/siteverify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      secret: process.env.HCAPTCHA_SECRET ?? '',
+      response: token,
+      remoteip: ip as string,
+    }),
+  });
+
+  const result = (await verify.json()) as { success: boolean };
+  if (!result.success) {
+    return res.status(403).json({ error: 'Invalid hCaptcha token' });
+  }
+
+  // TODO: handle actual submission
+
+  return res.status(200).json({ success: true });
+}


### PR DESCRIPTION
## Summary
- add `@upstash/ratelimit` and `@upstash/redis`
- create `pages/api/submit.ts` API route with Upstash rate limiting and hCaptcha validation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843977d6984832ab03d0210a3c995bb