### PR TITLE
Persist quiz answers with custom hook

### DIFF
--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -1,14 +1,12 @@
-import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import usePersistentQuizState from './usePersistentQuizState'
 
 function LandingPage() {
-  const [email, setEmail] = useState('')
+  const [quizState, setQuizState] = usePersistentQuizState()
   const navigate = useNavigate()
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    // Store email if needed
-    localStorage.setItem('userEmail', email)
     // Navigate to quiz page
     navigate('/quiz')
   }
@@ -29,8 +27,10 @@ function LandingPage() {
           <div>
             <input
               type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              value={quizState.email}
+              onChange={(e) =>
+                setQuizState((prev) => ({ ...prev, email: e.target.value }))
+              }
               placeholder="Enter your email"
               required
               className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"

--- a/src/Quiz.tsx
+++ b/src/Quiz.tsx
@@ -1,20 +1,13 @@
-import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import usePersistentQuizState from './usePersistentQuizState'
 
 function Quiz() {
-  const [urgency, setUrgency] = useState(3)
-  const [area, setArea] = useState('')
-  const [canPay, setCanPay] = useState(false)
+  const [quizState, setQuizState] = usePersistentQuizState()
+  const { urgency, area, canPay } = quizState.answers
   const navigate = useNavigate()
-  
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    // Store the quiz answers in localStorage to retrieve on risks summary page
-    localStorage.setItem('quizAnswers', JSON.stringify({
-      urgency,
-      area,
-      canPay
-    }))
     // Navigate to risks summary page
     navigate('/risks')
   }
@@ -44,7 +37,12 @@ function Quiz() {
                 min="1"
                 max="5"
                 value={urgency}
-                onChange={(e) => setUrgency(parseInt(e.target.value))}
+                onChange={(e) =>
+                  setQuizState((prev) => ({
+                    ...prev,
+                    answers: { ...prev.answers, urgency: parseInt(e.target.value) },
+                  }))
+                }
                 className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
               />
               <span className="text-sm text-gray-500">High</span>
@@ -67,7 +65,12 @@ function Quiz() {
                   name="area"
                   value="Cybersecurity"
                   checked={area === 'Cybersecurity'}
-                  onChange={(e) => setArea(e.target.value)}
+                  onChange={(e) =>
+                    setQuizState((prev) => ({
+                      ...prev,
+                      answers: { ...prev.answers, area: e.target.value },
+                    }))
+                  }
                   className="h-4 w-4 text-blue-600 focus:ring-blue-500"
                 />
                 <label htmlFor="cybersecurity" className="ml-2 text-gray-700">
@@ -81,7 +84,12 @@ function Quiz() {
                   name="area"
                   value="ERP integration"
                   checked={area === 'ERP integration'}
-                  onChange={(e) => setArea(e.target.value)}
+                  onChange={(e) =>
+                    setQuizState((prev) => ({
+                      ...prev,
+                      answers: { ...prev.answers, area: e.target.value },
+                    }))
+                  }
                   className="h-4 w-4 text-blue-600 focus:ring-blue-500"
                 />
                 <label htmlFor="erp" className="ml-2 text-gray-700">
@@ -95,7 +103,12 @@ function Quiz() {
                   name="area"
                   value="Supply chain"
                   checked={area === 'Supply chain'}
-                  onChange={(e) => setArea(e.target.value)}
+                  onChange={(e) =>
+                    setQuizState((prev) => ({
+                      ...prev,
+                      answers: { ...prev.answers, area: e.target.value },
+                    }))
+                  }
                   className="h-4 w-4 text-blue-600 focus:ring-blue-500"
                 />
                 <label htmlFor="supply" className="ml-2 text-gray-700">
@@ -113,10 +126,15 @@ function Quiz() {
             <div className="flex items-center space-x-4">
               <button
                 type="button"
-                onClick={() => setCanPay(false)}
+                onClick={() =>
+                  setQuizState((prev) => ({
+                    ...prev,
+                    answers: { ...prev.answers, canPay: false },
+                  }))
+                }
                 className={`px-4 py-2 rounded-md ${
-                  !canPay 
-                    ? 'bg-blue-600 text-white' 
+                  !canPay
+                    ? 'bg-blue-600 text-white'
                     : 'bg-gray-200 text-gray-700'
                 }`}
               >
@@ -124,10 +142,15 @@ function Quiz() {
               </button>
               <button
                 type="button"
-                onClick={() => setCanPay(true)}
+                onClick={() =>
+                  setQuizState((prev) => ({
+                    ...prev,
+                    answers: { ...prev.answers, canPay: true },
+                  }))
+                }
                 className={`px-4 py-2 rounded-md ${
-                  canPay 
-                    ? 'bg-blue-600 text-white' 
+                  canPay
+                    ? 'bg-blue-600 text-white'
                     : 'bg-gray-200 text-gray-700'
                 }`}
               >

--- a/src/RisksSummary.tsx
+++ b/src/RisksSummary.tsx
@@ -1,27 +1,14 @@
-import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
+import usePersistentQuizState from './usePersistentQuizState'
 
 function RisksSummary() {
-  const [answers, setAnswers] = useState<{
-    urgency: number;
-    area: string;
-    canPay: boolean;
-  } | null>(null)
+  const [quizState] = usePersistentQuizState()
+  const { answers } = quizState
   const navigate = useNavigate()
-  
-  useEffect(() => {
-    // Retrieve quiz answers from localStorage
-    const storedAnswers = localStorage.getItem('quizAnswers')
-    if (storedAnswers) {
-      setAnswers(JSON.parse(storedAnswers))
-    }
-  }, [])
   
   // Function to determine top risks based on quiz answers
   const getTopRisks = () => {
-    if (!answers) return ['No data available', 'No data available']
-    
-    const risks = []
+    const risks = [] as string[]
     
     // Risk based on area of concern
     switch(answers.area) {
@@ -55,13 +42,6 @@ function RisksSummary() {
     navigate('/')
   }
 
-  if (!answers) {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
-        <p>Loading your results...</p>
-      </div>
-    )
-  }
   
   const topRisks = getTopRisks()
 

--- a/src/Summary.tsx
+++ b/src/Summary.tsx
@@ -1,21 +1,10 @@
-import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
+import usePersistentQuizState, { DEFAULT_STATE } from './usePersistentQuizState'
 
 function Summary() {
-  const [answers, setAnswers] = useState<{
-    urgency: number;
-    area: string;
-    canPay: boolean;
-  } | null>(null)
+  const [quizState, setQuizState] = usePersistentQuizState()
+  const { answers } = quizState
   const navigate = useNavigate()
-  
-  useEffect(() => {
-    // Retrieve quiz answers from localStorage
-    const storedAnswers = localStorage.getItem('quizAnswers')
-    if (storedAnswers) {
-      setAnswers(JSON.parse(storedAnswers))
-    }
-  }, [])
   
   const getUrgencyText = (urgency: number) => {
     switch(urgency) {
@@ -29,18 +18,11 @@ function Summary() {
   }
   
   const handleStartOver = () => {
-    // Clear stored answers and return to landing page
-    localStorage.removeItem('quizAnswers')
+    // Reset stored answers and return to landing page
+    setQuizState(DEFAULT_STATE)
     navigate('/')
   }
 
-  if (!answers) {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
-        <p>Loading your results...</p>
-      </div>
-    )
-  }
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">

--- a/src/usePersistentQuizState.ts
+++ b/src/usePersistentQuizState.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect } from 'react'
+
+export interface QuizAnswers {
+  urgency: number
+  area: string
+  canPay: boolean
+}
+
+export interface QuizState {
+  email: string
+  answers: QuizAnswers
+}
+
+export const STORAGE_KEY = 'quizState'
+
+export const DEFAULT_STATE: QuizState = {
+  email: '',
+  answers: {
+    urgency: 3,
+    area: '',
+    canPay: false,
+  },
+}
+
+export default function usePersistentQuizState(): [QuizState, React.Dispatch<React.SetStateAction<QuizState>>] {
+  const [state, setState] = useState<QuizState>(() => {
+    if (typeof window === 'undefined') {
+      return DEFAULT_STATE
+    }
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        const parsed = JSON.parse(stored) as Partial<QuizState>
+        return {
+          email: parsed.email ?? DEFAULT_STATE.email,
+          answers: {
+            urgency: parsed.answers?.urgency ?? DEFAULT_STATE.answers.urgency,
+            area: parsed.answers?.area ?? DEFAULT_STATE.answers.area,
+            canPay: parsed.answers?.canPay ?? DEFAULT_STATE.answers.canPay,
+          },
+        }
+      }
+    } catch {
+      // ignore parse errors
+    }
+    return DEFAULT_STATE
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+    } catch {
+      // ignore write errors
+    }
+  }, [state])
+
+  return [state, setState]
+}


### PR DESCRIPTION
## Summary
- introduce `usePersistentQuizState` hook for localStorage sync
- use hook in landing page and quiz
- refactor summary pages to pull data from the hook

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684397a57f70832a97f3e138bbd9e1d2