### PR TITLE
Add Content Security Policy meta

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,16 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  const csp = "default-src 'self'; script-src 'self' https://vercel.com; style-src 'self'; object-src 'none';";
+  return (
+    <Html>
+      <Head>
+        <meta httpEquiv="Content-Security-Policy" content={csp} />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}


### PR DESCRIPTION
## Summary
- add Next.js `_document.tsx` with strict Content Security Policy meta tag

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843991a4140832aa8cfa2799f3be036