### PR TITLE
Add security policy page with footer link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import LandingPage from './LandingPage'
 import Quiz from './Quiz'
 import Summary from './Summary'
 import RisksSummary from './RisksSummary'
+import SecurityPolicy from './SecurityPolicy'
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Route path="/quiz" element={<Quiz />} />
         <Route path="/summary" element={<Summary />} />
         <Route path="/risks" element={<RisksSummary />} />
+        <Route path="/security-policy" element={<SecurityPolicy />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </Router>

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -1,0 +1,10 @@
+
+function Footer() {
+  return (
+    <footer className="fixed bottom-0 left-0 right-0 bg-gray-100 text-gray-600 text-sm py-3 text-center">
+      <a href="/security-policy" className="underline">Security Policy</a>
+    </footer>
+  )
+}
+
+export default Footer

--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import Footer from './Footer'
 
 function LandingPage() {
   const [email, setEmail] = useState('')
@@ -14,7 +15,7 @@ function LandingPage() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
+    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white pb-16">
       <main className="max-w-md w-full">
         <div className="text-center mb-12">
           <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
@@ -46,6 +47,7 @@ function LandingPage() {
           </div>
         </form>
       </main>
+      <Footer />
     </div>
   )
 }

--- a/src/Quiz.tsx
+++ b/src/Quiz.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import Footer from './Footer'
 
 function Quiz() {
   const [urgency, setUrgency] = useState(3)
@@ -20,7 +21,7 @@ function Quiz() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
+    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white pb-16">
       <main className="max-w-md w-full">
         <div className="text-center mb-8">
           <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-4">
@@ -152,6 +153,7 @@ function Quiz() {
           </div>
         </form>
       </main>
+      <Footer />
     </div>
   )
 }

--- a/src/RisksSummary.tsx
+++ b/src/RisksSummary.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
+import Footer from './Footer'
 
 function RisksSummary() {
   const [answers, setAnswers] = useState<{
@@ -57,7 +58,7 @@ function RisksSummary() {
 
   if (!answers) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
+      <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white pb-16">
         <p>Loading your results...</p>
       </div>
     )
@@ -66,7 +67,7 @@ function RisksSummary() {
   const topRisks = getTopRisks()
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
+    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white pb-16">
       <main className="max-w-md w-full">
         <div className="text-center mb-8">
           <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-6">
@@ -100,6 +101,7 @@ function RisksSummary() {
           </button>
         </div>
       </main>
+      <Footer />
     </div>
   )
 }

--- a/src/SecurityPolicy.tsx
+++ b/src/SecurityPolicy.tsx
@@ -1,0 +1,21 @@
+import Footer from './Footer'
+
+function SecurityPolicy() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white pb-16">
+      <main className="max-w-md w-full space-y-6">
+        <h1 className="text-3xl font-bold text-gray-900 text-center mb-4">Security Policy</h1>
+        <p className="text-gray-700 text-lg text-center">We take security seriously. Our current safeguards include:</p>
+        <ul className="list-disc pl-5 space-y-2 text-gray-700">
+          <li>Encryption of data in transit and at rest</li>
+          <li>Regular vulnerability assessments and patch management</li>
+          <li>Role-based access controls for all sensitive systems</li>
+          <li>Continuous monitoring of infrastructure</li>
+        </ul>
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+export default SecurityPolicy

--- a/src/Summary.tsx
+++ b/src/Summary.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
+import Footer from './Footer'
 
 function Summary() {
   const [answers, setAnswers] = useState<{
@@ -36,14 +37,14 @@ function Summary() {
 
   if (!answers) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
+      <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white pb-16">
         <p>Loading your results...</p>
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white">
+    <div className="min-h-screen flex flex-col items-center justify-center px-4 bg-white pb-16">
       <main className="max-w-md w-full">
         <div className="text-center mb-8">
           <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-4">
@@ -94,6 +95,7 @@ function Summary() {
           </button>
         </div>
       </main>
+      <Footer />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add footer component with Security Policy link
- create SecurityPolicy page listing safeguards
- update each page to display footer
- route `/security-policy` in app

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68439968f20c832a994864969c1ac6f7