### PR TITLE
Add RiskScoreCard component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.50.0",
         "react": "^19.1.0",
+        "react-circular-progressbar": "^2.2.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2",
         "resend": "^4.5.2"
@@ -4096,6 +4097,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-circular-progressbar": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.2.0.tgz",
+      "integrity": "sha512-cgyqEHOzB0nWMZjKfWN3MfSa1LV3OatcDjPz68lchXQUEiBD5O1WsAtoVK4/DSL0B4USR//cTdok4zCBkq8X5g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=0.14.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.50.0",
     "react": "^19.1.0",
+    "react-circular-progressbar": "^2.2.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",
     "resend": "^4.5.2"

--- a/src/components/RiskScoreCard.tsx
+++ b/src/components/RiskScoreCard.tsx
@@ -1,0 +1,57 @@
+import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
+import 'react-circular-progressbar/dist/styles.css';
+
+interface CategoryScore {
+  name: string;
+  score: number;
+}
+
+interface RiskScoreCardProps {
+  overallScore: number;
+  categoryScores: CategoryScore[];
+}
+
+function getColor(score: number): string {
+  if (score >= 80) return '#16a34a'; // green-600
+  if (score >= 60) return '#facc15'; // yellow-400
+  return '#dc2626'; // red-600
+}
+
+function RiskScoreCard({ overallScore, categoryScores }: RiskScoreCardProps) {
+  return (
+    <div className="bg-white rounded-xl shadow-sm p-6 grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-md mx-auto">
+      <div className="flex items-center justify-center">
+        <div className="w-32 h-32">
+          <CircularProgressbar
+            value={overallScore}
+            text={`${overallScore}%`}
+            styles={buildStyles({
+              textSize: '16px',
+              pathColor: getColor(overallScore),
+              textColor: '#4b5563',
+              trailColor: '#e5e7eb',
+            })}
+          />
+        </div>
+      </div>
+      <div className="space-y-4">
+        {categoryScores.map((cat) => (
+          <div key={cat.name}>
+            <div className="flex justify-between mb-1 text-sm text-gray-700">
+              <span>{cat.name}</span>
+              <span>{cat.score}%</span>
+            </div>
+            <div className="w-full bg-gray-200 rounded-md h-3">
+              <div
+                className="h-3 rounded-md"
+                style={{ width: `${cat.score}%`, backgroundColor: getColor(cat.score) }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default RiskScoreCard;


### PR DESCRIPTION
## Summary
- install `react-circular-progressbar`
- create `RiskScoreCard` component to display overall and per-category scores

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68439f0bf990832a878a0ce12aa4e3a5