### PR TITLE
Update landing page with ticker input

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import LandingPage from './LandingPage'
 import Quiz from './Quiz'
 import Summary from './Summary'
 import RisksSummary from './RisksSummary'
+import Score from './Score'
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Route path="/quiz" element={<Quiz />} />
         <Route path="/summary" element={<Summary />} />
         <Route path="/risks" element={<RisksSummary />} />
+        <Route path="/score/:ticker" element={<Score />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </Router>

--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -1,14 +1,16 @@
 import { useNavigate } from 'react-router-dom'
-import usePersistentQuizState from './usePersistentQuizState'
+import { useState } from 'react'
 
 function LandingPage() {
-  const [quizState, setQuizState] = usePersistentQuizState()
+  const [ticker, setTicker] = useState('')
   const navigate = useNavigate()
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    // Navigate to quiz page
-    navigate('/quiz')
+    const trimmed = ticker.trim().toUpperCase()
+    if (trimmed) {
+      navigate(`/score/${trimmed}`)
+    }
   }
 
   return (
@@ -25,15 +27,15 @@ function LandingPage() {
 
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
+            <label className="block mb-2 font-medium">
+              Enter a Biotech Ticker (e.g. SRPT, CRSP)
+            </label>
             <input
-              type="email"
-              value={quizState.email}
-              onChange={(e) =>
-                setQuizState((prev) => ({ ...prev, email: e.target.value }))
-              }
-              placeholder="Enter your email"
+              type="text"
+              value={ticker}
+              onChange={(e) => setTicker(e.target.value)}
               required
-              className="w-full max-w-xs md:max-w-md mx-auto px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full max-w-sm p-3 border rounded-md"
             />
           </div>
           <div className="text-center md:text-left">
@@ -41,7 +43,7 @@ function LandingPage() {
               type="submit"
               className="w-full md:w-auto mx-auto bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-4 rounded-md transition duration-200"
             >
-              Continue
+              Run Scorecard
             </button>
           </div>
         </form>

--- a/src/Score.tsx
+++ b/src/Score.tsx
@@ -1,0 +1,16 @@
+import { useParams } from 'react-router-dom'
+
+function Score() {
+  const { ticker } = useParams<{ ticker: string }>()
+
+  return (
+    <section className="min-h-screen flex flex-col items-center justify-center bg-slate-50 text-slate-800 p-6">
+      <main className="max-w-md w-full space-y-6 text-center">
+        <h1 className="text-2xl font-bold">{ticker?.toUpperCase()} Scorecard</h1>
+        <p>Coming soon.</p>
+      </main>
+    </section>
+  )
+}
+
+export default Score


### PR DESCRIPTION
## Summary
- replace quiz email capture with ticker input
- add placeholder Score page
- route /score/:ticker

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843aadbf320832a83b61f64e3a56a5b