### PR TITLE
Add Next.js score page

### DIFF
--- a/pages/score/[ticker].tsx
+++ b/pages/score/[ticker].tsx
@@ -1,0 +1,38 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { scoreCompany, ScoreBreakdown } from '../../utilities/scoreCompany';
+
+export default function ScorePage() {
+  const router = useRouter();
+  const { ticker } = router.query;
+  const [breakdown, setBreakdown] = useState<ScoreBreakdown | null>(null);
+
+  useEffect(() => {
+    if (typeof ticker === 'string') {
+      setBreakdown(scoreCompany(ticker));
+    }
+  }, [ticker]);
+
+  if (!ticker) return <p>Loading...</p>;
+
+  if (!breakdown) return <p>Scoring...</p>;
+
+  return (
+    <main style={{ padding: '2rem' }}>
+      <h1 style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>
+        {ticker.toUpperCase()} - Total Score: {breakdown.total}
+      </h1>
+      <ul style={{ marginTop: '1rem' }}>
+        {breakdown.categories.map((cat) => (
+          <li key={cat.name} style={{ marginBottom: '1rem' }}>
+            <h2 style={{ fontWeight: 'bold' }}>{cat.name} - {cat.score}</h2>
+            <p>{cat.rationale}</p>
+          </li>
+        ))}
+      </ul>
+      <button style={{ marginTop: '2rem' }}>
+        Download PDF
+      </button>
+    </main>
+  );
+}

--- a/utilities/scoreCompany.ts
+++ b/utilities/scoreCompany.ts
@@ -1,0 +1,38 @@
+export interface CategoryScore {
+  name: string;
+  score: number;
+  rationale: string;
+}
+
+export interface ScoreBreakdown {
+  total: number;
+  categories: CategoryScore[];
+}
+
+// Placeholder scoring function
+export function scoreCompany(ticker: string): ScoreBreakdown {
+  const seed = ticker.toUpperCase().charCodeAt(0) % 10;
+  const categories: CategoryScore[] = [
+    {
+      name: 'Financial Health',
+      score: 50 + seed,
+      rationale: 'Based on recent financial filings.'
+    },
+    {
+      name: 'Growth Potential',
+      score: 40 + seed,
+      rationale: 'Projected market expansion and revenue.'
+    },
+    {
+      name: 'Operational Risk',
+      score: 30 + seed,
+      rationale: 'Supply chain and execution considerations.'
+    }
+  ];
+
+  const total = Math.round(
+    categories.reduce((acc, cat) => acc + cat.score, 0) / categories.length
+  );
+
+  return { total, categories };
+}


### PR DESCRIPTION
## Summary
- add `scoreCompany` utility with placeholder scoring
- create Next.js dynamic route `/score/[ticker]`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843abc8e9d8832a8ed0cbe96b353252