### PR TITLE
Add mock scoring util and lint instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ npm run dev
 npm run build
 ```
 
+## Linting
+
+Ensure dependencies are installed with `npm install`, then run:
+
+```bash
+npm run lint
+```
+
 The `dist` directory will contain the optimized site with compiled Tailwind utilities.
 
 ## License

--- a/utilities/mockScoreCompany.ts
+++ b/utilities/mockScoreCompany.ts
@@ -1,0 +1,18 @@
+export interface CompanyScore {
+  score: number;
+  outOf: number;
+}
+
+export function mockScoreCompany(ticker: string): CompanyScore {
+  switch (ticker.toUpperCase()) {
+    case 'CRSP':
+      return { score: 21, outOf: 24 };
+    case 'SRPT':
+      return { score: 17, outOf: 24 };
+    case 'BMRN':
+      return { score: 13, outOf: 24 };
+    default:
+      return { score: 0, outOf: 24 };
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `mockScoreCompany` utility for placeholder scoring data
- document lint command in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843ab3a1478832a8397126d269f75d4