### PR TITLE
Update landing copy and merge latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ npm run dev
 npm run build
 ```
 
+## Linting
+
+Ensure dependencies are installed with `npm install`, then run:
+
+```bash
+npm run lint
+```
+
 The `dist` directory will contain the optimized site with compiled Tailwind utilities.
 
 ## License

--- a/pages/score/[ticker].tsx
+++ b/pages/score/[ticker].tsx
@@ -1,0 +1,38 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { scoreCompany, ScoreBreakdown } from '../../utilities/scoreCompany';
+
+export default function ScorePage() {
+  const router = useRouter();
+  const { ticker } = router.query;
+  const [breakdown, setBreakdown] = useState<ScoreBreakdown | null>(null);
+
+  useEffect(() => {
+    if (typeof ticker === 'string') {
+      setBreakdown(scoreCompany(ticker));
+    }
+  }, [ticker]);
+
+  if (!ticker) return <p>Loading...</p>;
+
+  if (!breakdown) return <p>Scoring...</p>;
+
+  return (
+    <main style={{ padding: '2rem' }}>
+      <h1 style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>
+        {ticker.toUpperCase()} - Total Score: {breakdown.total}
+      </h1>
+      <ul style={{ marginTop: '1rem' }}>
+        {breakdown.categories.map((cat) => (
+          <li key={cat.name} style={{ marginBottom: '1rem' }}>
+            <h2 style={{ fontWeight: 'bold' }}>{cat.name} - {cat.score}</h2>
+            <p>{cat.rationale}</p>
+          </li>
+        ))}
+      </ul>
+      <button style={{ marginTop: '2rem' }}>
+        Download PDF
+      </button>
+    </main>
+  );
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import LandingPage from './LandingPage'
 import Quiz from './Quiz'
 import Summary from './Summary'
 import RisksSummary from './RisksSummary'
+import Score from './Score'
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Route path="/quiz" element={<Quiz />} />
         <Route path="/summary" element={<Summary />} />
         <Route path="/risks" element={<RisksSummary />} />
+        <Route path="/score/:ticker" element={<Score />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </Router>

--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -7,8 +7,10 @@ function LandingPage() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    // Navigate to quiz page
-    navigate('/quiz')
+    const trimmed = quizState.ticker.trim().toUpperCase()
+    if (trimmed) {
+      navigate(`/score/${trimmed}`)
+    }
   }
 
   return (
@@ -16,32 +18,38 @@ function LandingPage() {
       <main className="max-w-md w-full">
         <div className="text-center mb-12">
           <h1 className="text-3xl lg:text-6xl font-bold mb-6">
-            Worried your next deal's IT/ops risk is hidden?
+            Find Overlooked Biotech Winners Before Wall Street Does
           </h1>
           <p className="prose prose-sm md:prose mb-8 mx-auto">
-            Get a 1-page execution risk snapshot<br />in under 5 minutes.
+            Get a complete risk-adjusted diligence score on any biotech in 30 seconds. Built for investors, scouts, and founders.
           </p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
+            <label className="block mb-2 font-medium">
+              Enter a Biotech Ticker (e.g. SRPT, CRSP)
+            </label>
             <input
-              type="email"
-              value={quizState.email}
+              type="text"
+              value={quizState.ticker}
               onChange={(e) =>
-                setQuizState((prev) => ({ ...prev, email: e.target.value }))
+                setQuizState((prev) => ({ ...prev, ticker: e.target.value }))
               }
-              placeholder="Enter your email"
+              placeholder="Enter Ticker"
               required
-              className="w-full max-w-xs md:max-w-md mx-auto px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full max-w-sm p-3 border rounded-md"
             />
+            <p className="text-sm mt-2 text-center text-gray-600">
+              Don’t know a ticker? Try CRSP
+            </p>
           </div>
           <div className="text-center md:text-left">
             <button
               type="submit"
               className="w-full md:w-auto mx-auto bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-4 rounded-md transition duration-200"
             >
-              Continue
+              Run Scorecard
             </button>
           </div>
         </form>

--- a/src/Score.tsx
+++ b/src/Score.tsx
@@ -1,0 +1,16 @@
+import { useParams } from 'react-router-dom'
+
+function Score() {
+  const { ticker } = useParams<{ ticker: string }>()
+
+  return (
+    <section className="min-h-screen flex flex-col items-center justify-center bg-slate-50 text-slate-800 p-6">
+      <main className="max-w-md w-full space-y-6 text-center">
+        <h1 className="text-2xl font-bold">{ticker?.toUpperCase()} Scorecard</h1>
+        <p>Coming soon.</p>
+      </main>
+    </section>
+  )
+}
+
+export default Score

--- a/src/usePersistentQuizState.ts
+++ b/src/usePersistentQuizState.ts
@@ -7,14 +7,14 @@ export interface QuizAnswers {
 }
 
 export interface QuizState {
-  email: string
+  ticker: string
   answers: QuizAnswers
 }
 
 export const STORAGE_KEY = 'quizState'
 
 export const DEFAULT_STATE: QuizState = {
-  email: '',
+  ticker: '',
   answers: {
     urgency: 3,
     area: '',
@@ -32,7 +32,7 @@ export default function usePersistentQuizState(): [QuizState, React.Dispatch<Rea
       if (stored) {
         const parsed = JSON.parse(stored) as Partial<QuizState>
         return {
-          email: parsed.email ?? DEFAULT_STATE.email,
+            ticker: parsed.ticker ?? DEFAULT_STATE.ticker,
           answers: {
             urgency: parsed.answers?.urgency ?? DEFAULT_STATE.answers.urgency,
             area: parsed.answers?.area ?? DEFAULT_STATE.answers.area,

--- a/utilities/mockScoreCompany.ts
+++ b/utilities/mockScoreCompany.ts
@@ -1,0 +1,18 @@
+export interface CompanyScore {
+  score: number;
+  outOf: number;
+}
+
+export function mockScoreCompany(ticker: string): CompanyScore {
+  switch (ticker.toUpperCase()) {
+    case 'CRSP':
+      return { score: 21, outOf: 24 };
+    case 'SRPT':
+      return { score: 17, outOf: 24 };
+    case 'BMRN':
+      return { score: 13, outOf: 24 };
+    default:
+      return { score: 0, outOf: 24 };
+  }
+}
+

--- a/utilities/scoreCompany.ts
+++ b/utilities/scoreCompany.ts
@@ -1,0 +1,38 @@
+export interface CategoryScore {
+  name: string;
+  score: number;
+  rationale: string;
+}
+
+export interface ScoreBreakdown {
+  total: number;
+  categories: CategoryScore[];
+}
+
+// Placeholder scoring function
+export function scoreCompany(ticker: string): ScoreBreakdown {
+  const seed = ticker.toUpperCase().charCodeAt(0) % 10;
+  const categories: CategoryScore[] = [
+    {
+      name: 'Financial Health',
+      score: 50 + seed,
+      rationale: 'Based on recent financial filings.'
+    },
+    {
+      name: 'Growth Potential',
+      score: 40 + seed,
+      rationale: 'Projected market expansion and revenue.'
+    },
+    {
+      name: 'Operational Risk',
+      score: 30 + seed,
+      rationale: 'Supply chain and execution considerations.'
+    }
+  ];
+
+  const total = Math.round(
+    categories.reduce((acc, cat) => acc + cat.score, 0) / categories.length
+  );
+
+  return { total, categories };
+}


### PR DESCRIPTION
## Summary
- merge latest main updates bringing in score utilities and page
- resolve landing page merge conflicts and keep biotech-focused copy
- persist ticker input between pages using local storage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843abb5d078832a878a23424f6d8ee6