### PR TITLE
Add ticker scorecard pages

### DIFF
--- a/components/ScorecardRenderer.tsx
+++ b/components/ScorecardRenderer.tsx
@@ -1,0 +1,25 @@
+import { Scorecard } from '../lib/scoreCompany'
+
+interface Props {
+  scorecard: Scorecard
+}
+
+export default function ScorecardRenderer({ scorecard }: Props) {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold text-center">
+        {scorecard.ticker.toUpperCase()} - Total Score: {scorecard.score}
+      </h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {scorecard.breakdown.map((item) => (
+          <div key={item.category} className="bg-slate-50 rounded-lg p-4 shadow-sm">
+            <h2 className="font-bold mb-2">
+              {item.category} - {item.score}/3
+            </h2>
+            <p>{item.rationale}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/lib/scoreCompany.ts
+++ b/lib/scoreCompany.ts
@@ -1,0 +1,34 @@
+export interface ScoreBreakdownItem {
+  category: string
+  score: number
+  rationale: string
+}
+
+export interface Scorecard {
+  ticker: string
+  score: number
+  breakdown: ScoreBreakdownItem[]
+}
+
+export async function scoreCompany(ticker: string): Promise<Scorecard> {
+  const categories = [
+    'Financial Health',
+    'Growth Potential',
+    'Operational Risk',
+    'Pipeline Strength',
+  ]
+
+  const breakdown = categories.map((category) => ({
+    category,
+    score: Math.floor(Math.random() * 4),
+    rationale: 'Placeholder rationale for ' + category,
+  }))
+
+  const total = breakdown.reduce((acc, item) => acc + item.score, 0)
+
+  return {
+    ticker: ticker.toUpperCase(),
+    score: total,
+    breakdown,
+  }
+}

--- a/pages/api/scoreCompany.ts
+++ b/pages/api/scoreCompany.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { scoreCompany } from '../../lib/scoreCompany'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+
+  const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body
+  const { ticker } = body ?? {}
+
+  if (!ticker || typeof ticker !== 'string') {
+    res.status(400).json({ error: 'Invalid ticker' })
+    return
+  }
+
+  const result = await scoreCompany(ticker)
+  res.status(200).json(result)
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,38 @@
+import { useRouter } from 'next/router'
+import { useState, FormEvent } from 'react'
+
+export default function Home() {
+  const router = useRouter()
+  const [ticker, setTicker] = useState('')
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const trimmed = ticker.trim().toUpperCase()
+    if (trimmed) {
+      void router.push(`/score/${trimmed}`)
+    }
+  }
+
+  return (
+    <section className="min-h-screen flex items-center justify-center bg-slate-50 p-6">
+      <form onSubmit={handleSubmit} className="space-y-4 text-center">
+        <label className="block text-lg font-medium">
+          Enter Biotech Ticker (e.g. SRPT)
+        </label>
+        <input
+          type="text"
+          value={ticker}
+          onChange={(e) => setTicker(e.target.value)}
+          required
+          className="w-full max-w-sm p-3 border rounded-md shadow-md"
+        />
+        <button
+          type="submit"
+          className="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded-md transition"
+        >
+          Run Scorecard
+        </button>
+      </form>
+    </section>
+  )
+}

--- a/pages/score/[ticker].tsx
+++ b/pages/score/[ticker].tsx
@@ -1,38 +1,28 @@
-import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
-import { scoreCompany, ScoreBreakdown } from '../../utilities/scoreCompany';
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { scoreCompany, Scorecard } from '../../lib/scoreCompany'
+import ScorecardRenderer from '../../components/ScorecardRenderer'
 
 export default function ScorePage() {
-  const router = useRouter();
-  const { ticker } = router.query;
-  const [breakdown, setBreakdown] = useState<ScoreBreakdown | null>(null);
+  const router = useRouter()
+  const { ticker } = router.query
+  const [scorecard, setScorecard] = useState<Scorecard | null>(null)
 
   useEffect(() => {
     if (typeof ticker === 'string') {
-      setBreakdown(scoreCompany(ticker));
+      void scoreCompany(ticker).then(setScorecard)
     }
-  }, [ticker]);
+  }, [ticker])
 
-  if (!ticker) return <p>Loading...</p>;
-
-  if (!breakdown) return <p>Scoring...</p>;
+  if (!ticker) {
+    return <p className="p-6">Loading...</p>
+  }
 
   return (
-    <main style={{ padding: '2rem' }}>
-      <h1 style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>
-        {ticker.toUpperCase()} - Total Score: {breakdown.total}
-      </h1>
-      <ul style={{ marginTop: '1rem' }}>
-        {breakdown.categories.map((cat) => (
-          <li key={cat.name} style={{ marginBottom: '1rem' }}>
-            <h2 style={{ fontWeight: 'bold' }}>{cat.name} - {cat.score}</h2>
-            <p>{cat.rationale}</p>
-          </li>
-        ))}
-      </ul>
-      <button style={{ marginTop: '2rem' }}>
-        Download PDF
-      </button>
-    </main>
-  );
+    <section className="min-h-screen flex items-center justify-center bg-slate-50 p-6">
+      <div className="bg-white shadow-md rounded-md p-6 space-y-4 w-full max-w-2xl">
+        {scorecard ? <ScorecardRenderer scorecard={scorecard} /> : <p>Scoring...</p>}
+      </div>
+    </section>
+  )
 }


### PR DESCRIPTION
## Summary
- add ticker entry form page using Next.js routing
- implement dynamic score page with placeholder renderer
- generate scorecards with mock data
- expose API endpoint for scoring
- share a component for rendering score details

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843b45f6f84832a8db7a7bf91056f52