### PR TITLE
Improve hero design and polish scorecard UI

### DIFF
--- a/components/ScorecardRenderer.tsx
+++ b/components/ScorecardRenderer.tsx
@@ -1,22 +1,45 @@
+import { CircularProgressbar, buildStyles } from 'react-circular-progressbar'
 import { Scorecard } from '../lib/scoreCompany'
+import 'react-circular-progressbar/dist/styles.css'
 
 interface Props {
   scorecard: Scorecard
 }
 
 export default function ScorecardRenderer({ scorecard }: Props) {
+  const totalPossible = scorecard.breakdown.length * 3
+  const percent = Math.round((scorecard.score / totalPossible) * 100)
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-xl font-bold text-center">
-        {scorecard.ticker.toUpperCase()} - Total Score: {scorecard.score}
-      </h1>
+    <div className="space-y-6">
+      <div className="flex flex-col items-center space-y-2">
+        <div className="w-24 h-24">
+          <CircularProgressbar
+            value={percent}
+            text={`${percent}%`}
+            styles={buildStyles({
+              pathColor: '#10b981',
+              textColor: '#0f172a',
+              trailColor: '#e2e8f0',
+            })}
+          />
+        </div>
+        <h1 className="text-3xl font-bold">
+          {scorecard.ticker.toUpperCase()}
+        </h1>
+      </div>
+
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {scorecard.breakdown.map((item) => (
-          <div key={item.category} className="bg-slate-50 rounded-lg p-4 shadow-sm">
-            <h2 className="font-bold mb-2">
-              {item.category} - {item.score}/3
-            </h2>
-            <p>{item.rationale}</p>
+          <div
+            key={item.category}
+            className="bg-slate-50 p-4 rounded-lg shadow-sm flex justify-between items-start"
+          >
+            <div>
+              <h2 className="font-bold">{item.category}</h2>
+              <p className="text-sm text-slate-700">{item.rationale}</p>
+            </div>
+            <span className="font-semibold">{item.score}/3</span>
           </div>
         ))}
       </div>

--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -14,44 +14,68 @@ function LandingPage() {
   }
 
   return (
-    <section className="min-h-screen flex flex-col items-center justify-center bg-slate-50 text-slate-800 p-6">
-      <main className="max-w-md w-full">
-        <div className="text-center mb-12">
-          <h1 className="text-3xl lg:text-6xl font-bold mb-6">
-            Worried your next deal's IT/ops risk is hidden?
-          </h1>
-          <p className="prose prose-sm md:prose mb-8 mx-auto">
-            Get a 1-page execution risk snapshot<br />in under 5 minutes.
-          </p>
+    <section className="bg-slate-50 min-h-screen">
+      <div className="max-w-2xl mx-auto text-center space-y-6 py-16 px-6">
+        <h1 className="text-4xl sm:text-5xl font-serif tracking-tight text-slate-900">
+          Discover Overlooked Biotech Winners
+        </h1>
+        <p className="text-slate-700 leading-relaxed">
+          Run a complete investor-grade scorecard on any ticker in 30 seconds.
+        </p>
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col sm:flex-row items-center justify-center gap-3"
+        >
+          <input
+            type="text"
+            placeholder="Enter ticker (e.g. CRSP)"
+            value={ticker}
+            onChange={(e) => setTicker(e.target.value)}
+            required
+            className="flex-1 border border-slate-300 rounded-md px-4 py-3"
+          />
+          <button type="submit" className="btn-primary sm:w-auto w-full">
+            Run Scorecard
+          </button>
+        </form>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 text-sm pt-8">
+          <div className="space-y-2">
+            <div className="text-2xl">🧬</div>
+            <p>Evidence-Based Scoring</p>
+          </div>
+          <div className="space-y-2">
+            <div className="text-2xl">📊</div>
+            <p>24-Point Diligence Rubric</p>
+          </div>
+          <div className="space-y-2">
+            <div className="text-2xl">🔬</div>
+            <p>Built for Asymmetric Alpha</p>
+          </div>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-6">
-          <div>
-            <label className="block mb-2 font-medium">
-              Enter a Biotech Ticker (e.g. SRPT, CRSP)
-            </label>
-            <input
-              type="text"
-              value={ticker}
-              onChange={(e) => setTicker(e.target.value)}
-              required
-              className="w-full max-w-sm p-3 border rounded-md"
-            />
-          </div>
-          <div className="text-center md:text-left">
-            <button
-              type="submit"
-              className="w-full md:w-auto mx-auto bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-4 rounded-md transition duration-200"
-            >
-              Run Scorecard
-            </button>
-          </div>
-        </form>
-        <p className="text-center text-sm mt-4">
-          We follow basic cybersecurity hygiene including rate limiting,
-          spam protection, and no third-party sharing.
+        <p className="text-center text-xs text-slate-500 pt-6">
+          We follow basic cybersecurity hygiene including rate limiting and no
+          third-party sharing.
         </p>
-      </main>
+      </div>
+
+      {/* Mobile CTA Bar */}
+      <div className="fixed bottom-0 inset-x-0 bg-white shadow-md p-4 z-50 sm:hidden">
+        <form onSubmit={handleSubmit} className="flex items-center gap-2">
+          <input
+            type="text"
+            placeholder="Ticker"
+            value={ticker}
+            onChange={(e) => setTicker(e.target.value)}
+            required
+            className="flex-1 border border-slate-300 rounded-md px-3 py-2"
+          />
+          <button type="submit" className="btn-primary">
+            Run
+          </button>
+        </form>
+      </div>
     </section>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -3,35 +3,42 @@
 @tailwind utilities;
 
 
+
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
   color-scheme: light;
-  color: #1e293b;
-  background-color: #f8fafc;
-  
+  color: #334155; /* slate-700 */
+  background-color: #f8fafc; /* slate-50 */
+
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-h1 {
-  @apply font-serif tracking-tight text-slate-800;
-}
-
-p {
-  @apply font-sans tracking-tight text-slate-800;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  @apply font-serif tracking-tight text-slate-900;
 }
 
 body {
+  @apply font-sans text-slate-700 leading-relaxed bg-slate-50;
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+}
+
+@layer components {
+  .btn-primary {
+    @apply bg-emerald-600 text-white hover:bg-emerald-700 rounded-md transition-colors px-4 py-3;
+  }
 }
 
 #root {


### PR DESCRIPTION
## Summary
- globally style typography and button colors
- redesign landing hero with feature grid and mobile CTA bar
- add progress indicator and card styles to the scorecard renderer

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843ba2fc92c832a84bb4c0c22c28c2a