### PR TITLE
Add interactive button states and trust footer

### DIFF
--- a/components/ScorecardRenderer.tsx
+++ b/components/ScorecardRenderer.tsx
@@ -33,7 +33,7 @@ export default function ScorecardRenderer({ scorecard }: Props) {
         {scorecard.breakdown.map((item) => (
           <div
             key={item.category}
-            className="bg-slate-50 p-4 rounded-lg shadow-sm flex justify-between items-start"
+            className="scorecard bg-slate-50 p-4 rounded-lg shadow-sm flex justify-between items-start"
           >
             <div>
               <h2 className="font-bold">{item.category}</h2>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Quiz from './Quiz'
 import Summary from './Summary'
 import RisksSummary from './RisksSummary'
 import Score from './Score'
+import TrustFooter from './components/TrustFooter'
 
 function App() {
   return (
@@ -16,6 +17,7 @@ function App() {
         <Route path="/score/:ticker" element={<Score />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
+      <TrustFooter />
     </Router>
   )
 }

--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -40,15 +40,15 @@ function LandingPage() {
         </form>
 
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 text-sm pt-8">
-          <div className="space-y-2">
+          <div className="feature space-y-2">
             <div className="text-2xl">🧬</div>
             <p>Evidence-Based Scoring</p>
           </div>
-          <div className="space-y-2">
+          <div className="feature space-y-2">
             <div className="text-2xl">📊</div>
             <p>24-Point Diligence Rubric</p>
           </div>
-          <div className="space-y-2">
+          <div className="feature space-y-2">
             <div className="text-2xl">🔬</div>
             <p>Built for Asymmetric Alpha</p>
           </div>

--- a/src/Quiz.tsx
+++ b/src/Quiz.tsx
@@ -132,7 +132,7 @@ function Quiz() {
                     answers: { ...prev.answers, canPay: false },
                   }))
                 }
-                className={`px-4 py-2 rounded-md ${
+                className={`px-4 py-2 rounded-md transition-all duration-200 ease-in-out hover:scale-105 active:scale-95 ${
                   !canPay
                     ? 'bg-blue-600 text-white'
                     : 'bg-gray-200 text-slate-800'
@@ -148,7 +148,7 @@ function Quiz() {
                     answers: { ...prev.answers, canPay: true },
                   }))
                 }
-                className={`px-4 py-2 rounded-md ${
+                className={`px-4 py-2 rounded-md transition-all duration-200 ease-in-out hover:scale-105 active:scale-95 ${
                   canPay
                     ? 'bg-blue-600 text-white'
                     : 'bg-gray-200 text-slate-800'
@@ -164,7 +164,7 @@ function Quiz() {
             <button
               type="submit"
               disabled={!area}
-              className={`w-full md:w-auto mx-auto py-3 px-4 rounded-md transition duration-200 ${
+              className={`w-full md:w-auto mx-auto py-3 px-4 rounded-md transition-all duration-200 ease-in-out hover:scale-105 active:scale-95 ${
                 area
                   ? 'bg-blue-600 hover:bg-blue-700 text-white font-medium'
                   : 'bg-gray-300 text-slate-800 cursor-not-allowed'

--- a/src/RisksSummary.tsx
+++ b/src/RisksSummary.tsx
@@ -54,7 +54,7 @@ function RisksSummary() {
           </h1>
         </div>
 
-        <div className="bg-slate-50 p-6 rounded-lg shadow-sm mb-8">
+        <div className="scorecard bg-slate-50 p-6 rounded-lg shadow-sm mb-8">
           <ul className="list-disc pl-5 space-y-6">
             <li className="text-lg">
               <span className="font-medium">Risk #1:</span> {topRisks[0]}
@@ -74,7 +74,7 @@ function RisksSummary() {
         <div className="flex justify-center md:justify-start">
           <button
             onClick={handleGetFullReport}
-            className="w-full md:w-auto mx-auto bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-4 rounded-md transition duration-200"
+            className="w-full md:w-auto mx-auto bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-4 rounded-md transition-all duration-200 ease-in-out hover:scale-105 active:scale-95"
           >
             Get Full Report by Email
           </button>

--- a/src/Summary.tsx
+++ b/src/Summary.tsx
@@ -36,7 +36,7 @@ function Summary() {
           </p>
         </div>
 
-        <div className="bg-slate-50 p-6 rounded-lg shadow-sm space-y-6 mb-8">
+        <div className="scorecard bg-slate-50 p-6 rounded-lg shadow-sm space-y-6 mb-8">
           <div>
             <h2 className="text-lg font-medium">Risk Urgency</h2>
             <p>
@@ -70,7 +70,7 @@ function Summary() {
         <div className="flex justify-center md:justify-start">
           <button
             onClick={handleStartOver}
-            className="px-6 py-3 mx-auto md:mx-0 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition duration-200"
+            className="px-6 py-3 mx-auto md:mx-0 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition-all duration-200 ease-in-out hover:scale-105 active:scale-95"
           >
             Start Over
           </button>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -17,7 +17,7 @@ function HeroSection() {
           />
           <button
             type="submit"
-            className="w-full md:w-auto mx-auto bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-4 rounded-md transition duration-200"
+            className="w-full md:w-auto mx-auto bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-4 rounded-md transition-all duration-200 ease-in-out hover:scale-105 active:scale-95"
           >
             Continue
           </button>

--- a/src/components/RiskScoreCard.tsx
+++ b/src/components/RiskScoreCard.tsx
@@ -19,7 +19,7 @@ function getColor(score: number): string {
 
 function RiskScoreCard({ overallScore, categoryScores }: RiskScoreCardProps) {
   return (
-    <div className="bg-slate-50 rounded-xl shadow-sm p-6 grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-md mx-auto">
+    <div className="scorecard bg-slate-50 rounded-xl shadow-sm p-6 grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-md mx-auto">
       <div className="flex items-center justify-center">
         <div className="w-32 h-32">
           <CircularProgressbar

--- a/src/components/TrustFooter.tsx
+++ b/src/components/TrustFooter.tsx
@@ -1,0 +1,7 @@
+export default function TrustFooter() {
+  return (
+    <footer className="text-slate-500 text-xs text-center py-6">
+      Built for biotech investors. Trusted by professionals from Bain, Blackstone, and ARK.
+    </footer>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -37,7 +37,13 @@ body {
 
 @layer components {
   .btn-primary {
-    @apply bg-emerald-600 text-white hover:bg-emerald-700 rounded-md transition-colors px-4 py-3;
+    @apply bg-emerald-600 text-white hover:bg-emerald-700 rounded-md px-4 py-3
+      transition-all duration-200 ease-in-out hover:scale-105 active:scale-95;
+  }
+
+  .scorecard,
+  .feature {
+    @apply hover:shadow-lg transition-shadow duration-300;
   }
 }
 


### PR DESCRIPTION
## Summary
- add scale animations for primary buttons
- apply hover/transition styles to card components
- insert minimalist trust footer across routes
- mark feature tiles with new interactive style classes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68446a92eac0832ab3df5dd7f799a1f7