### PR TITLE
Implement scorecard rendering

### DIFF
--- a/components/ScorecardRenderer.tsx
+++ b/components/ScorecardRenderer.tsx
@@ -1,5 +1,5 @@
 import { CircularProgressbar, buildStyles } from 'react-circular-progressbar'
-import { Scorecard } from '../lib/scoreCompany'
+import type { Scorecard } from '../lib/scoreCompany'
 import 'react-circular-progressbar/dist/styles.css'
 
 interface Props {

--- a/src/Score.tsx
+++ b/src/Score.tsx
@@ -1,13 +1,24 @@
+import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
+import ScorecardRenderer from '../components/ScorecardRenderer'
+import { scoreCompany } from '../lib/scoreCompany'
+import type { Scorecard } from '../lib/scoreCompany'
 
 function Score() {
   const { ticker } = useParams<{ ticker: string }>()
+  const [scorecard, setScorecard] = useState<Scorecard | null>(null)
+
+  useEffect(() => {
+    if (ticker) {
+      void scoreCompany(ticker).then(setScorecard)
+    }
+  }, [ticker])
 
   return (
     <section className="min-h-screen flex flex-col items-center justify-center bg-slate-50 text-slate-800 p-6">
       <main className="max-w-md w-full space-y-6 text-center">
         <h1 className="text-2xl font-bold">{ticker?.toUpperCase()} Scorecard</h1>
-        <p>Coming soon.</p>
+        {scorecard ? <ScorecardRenderer scorecard={scorecard} /> : <p>Scoring...</p>}
       </main>
     </section>
   )


### PR DESCRIPTION
## Summary
- show a generated scorecard after entering a ticker
- fix TypeScript build errors by using type-only imports

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844739a80d4832ab6515270c9374900