### PR TITLE
Refactor ScorecardRenderer and add sample data

### DIFF
--- a/components/ScorecardRenderer.tsx
+++ b/components/ScorecardRenderer.tsx
@@ -1,8 +1,8 @@
 import type { Scorecard, ScoreCategory } from '../lib/computeScorecard'
-import { createScorecardPdf } from '../utilities/createScorecardPdf'
 
 interface Props {
   scorecard: Scorecard
+  actions?: React.ReactNode
 }
 
 function diligenceSignal(total: number): string {
@@ -11,20 +11,7 @@ function diligenceSignal(total: number): string {
   return 'Low'
 }
 
-export default function ScorecardRenderer({ scorecard }: Props) {
-  async function handleDownload() {
-    const bytes = await createScorecardPdf(scorecard)
-    const blob = new Blob([bytes], { type: 'application/pdf' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `${scorecard.ticker}-scorecard.pdf`
-    a.click()
-    URL.revokeObjectURL(url)
-  }
-  function handleWatchlist() {
-    console.log('add to watchlist', scorecard.ticker)
-  }
+export default function ScorecardRenderer({ scorecard, actions }: Props) {
 
   return (
     <div className="max-w-5xl mx-auto py-12 space-y-8">
@@ -34,15 +21,7 @@ export default function ScorecardRenderer({ scorecard }: Props) {
         <div className="text-sm text-slate-600">
           Diligence Signal: {diligenceSignal(scorecard.total)}
         </div>
-        <div className="flex justify-center gap-4 pt-2">
-          <button className="btn-primary" onClick={handleDownload}>Download PDF</button>
-          <button
-            className="bg-slate-200 text-slate-700 rounded-md px-4 py-3 hover:bg-slate-300"
-            onClick={handleWatchlist}
-          >
-            Watchlist
-          </button>
-        </div>
+        {actions && <div className="flex justify-center gap-4 pt-2">{actions}</div>}
       </header>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">

--- a/lib/sampleScorecards.ts
+++ b/lib/sampleScorecards.ts
@@ -1,0 +1,75 @@
+import type { Scorecard } from './computeScorecard'
+
+export const crspScorecard: Scorecard = {
+  ticker: 'CRSP',
+  total: 11.41,
+  categories: [
+    {
+      name: 'Pipeline Maturity',
+      score: 1.75,
+      factors: [
+        { label: 'Lead candidate stage', score: 3, weight: 1, rationale: 'Stage of the most advanced asset.' },
+        { label: 'Breadth of pipeline', score: 0, weight: 0.5, rationale: 'Number of additional active programs.' },
+        { label: 'Trial diversity', score: 1, weight: 0.5, rationale: 'Variety of modalities or indications.' }
+      ]
+    },
+    {
+      name: 'Financial Health',
+      score: 2,
+      factors: [
+        { label: 'Cash runway', score: 3, weight: 1, rationale: 'Months of operational runway.' },
+        { label: 'Debt load', score: 1, weight: 1, rationale: 'Outstanding liabilities and covenants.' }
+      ]
+    },
+    {
+      name: 'Market Position',
+      score: 1,
+      factors: [
+        { label: 'Competition intensity', score: 1, weight: 1, rationale: 'Number of similar programs in market.' },
+        { label: 'IP strength', score: 1, weight: 1, rationale: 'Patent portfolio and exclusivity.' }
+      ]
+    },
+    {
+      name: 'Team Experience',
+      score: 0.67,
+      factors: [
+        { label: 'Leadership track record', score: 1, weight: 1, rationale: 'Past exits or approvals.' },
+        { label: 'Scientific advisory', score: 0, weight: 0.5, rationale: 'Credibility of advisors.' }
+      ]
+    },
+    {
+      name: 'Operational Risk',
+      score: 0,
+      factors: [
+        { label: 'Manufacturing readiness', score: 0, weight: 1, rationale: 'CMO relationships and scale-up plans.' },
+        { label: 'Supply chain complexity', score: 0, weight: 0.5, rationale: 'Reliance on scarce materials.' }
+      ]
+    },
+    {
+      name: 'Regulatory Strategy',
+      score: 1.33,
+      factors: [
+        { label: 'FDA interactions', score: 1, weight: 1, rationale: 'Experience with regulatory bodies.' },
+        { label: 'Compliance track', score: 2, weight: 0.5, rationale: 'History of clinical holds or warnings.' }
+      ]
+    },
+    {
+      name: 'Commercialization Plan',
+      score: 2.33,
+      factors: [
+        { label: 'Partnerships', score: 3, weight: 1, rationale: 'Distribution or co-development deals.' },
+        { label: 'Launch readiness', score: 1, weight: 0.5, rationale: 'Internal or outsourced sales capacity.' }
+      ]
+    },
+    {
+      name: 'Funding Outlook',
+      score: 2.33,
+      factors: [
+        { label: 'Access to capital', score: 3, weight: 1, rationale: 'Relationships with investors or grants.' },
+        { label: 'Burn rate discipline', score: 1, weight: 0.5, rationale: 'Historical cash utilization.' }
+      ]
+    }
+  ],
+  comments:
+    'This company presents a strong IP moat and disciplined cash burn, but its lead indication faces crowding risk.'
+}

--- a/src/Score.tsx
+++ b/src/Score.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import ScorecardRenderer from '../components/ScorecardRenderer'
 import { computeScorecard } from '../lib/computeScorecard'
+import { createScorecardPdf } from '../utilities/createScorecardPdf'
 import type { Scorecard } from '../lib/computeScorecard'
 
 function Score() {
@@ -14,11 +15,45 @@ function Score() {
     }
   }, [ticker])
 
+  async function handleDownload() {
+    if (!scorecard) return
+    const bytes = await createScorecardPdf(scorecard)
+    const blob = new Blob([bytes], { type: 'application/pdf' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${scorecard.ticker}-scorecard.pdf`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  function handleWatchlist() {
+    if (scorecard) console.log('add to watchlist', scorecard.ticker)
+  }
+
+  const actions = (
+    <>
+      <button className="btn-primary" onClick={handleDownload}>
+        Download PDF
+      </button>
+      <button
+        className="bg-slate-200 text-slate-700 rounded-md px-4 py-3 hover:bg-slate-300"
+        onClick={handleWatchlist}
+      >
+        Watchlist
+      </button>
+    </>
+  )
+
   return (
     <section className="min-h-screen flex flex-col items-center justify-center bg-slate-50 text-slate-800 p-6">
       <main className="max-w-md w-full space-y-6 text-center">
         <h1 className="text-2xl font-bold">{ticker?.toUpperCase()} Scorecard</h1>
-        {scorecard ? <ScorecardRenderer scorecard={scorecard} /> : <p>Scoring...</p>}
+        {scorecard ? (
+          <ScorecardRenderer scorecard={scorecard} actions={actions} />
+        ) : (
+          <p>Scoring...</p>
+        )}
       </main>
     </section>
   )


### PR DESCRIPTION
## Summary
- add dedicated `sampleScorecards.ts` module exporting a `crspScorecard`
- refactor `ScorecardRenderer` to accept `actions` prop for optional controls
- move PDF download/watchlist logic into `Score.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844a5237010832a81546c40b1c9f5c2