### PR TITLE
Show placeholder for tickers without sample data

### DIFF
--- a/src/Score.tsx
+++ b/src/Score.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import ScorecardRenderer from '../components/ScorecardRenderer'
-import { computeScorecard } from '../lib/computeScorecard'
 import { crspScorecard } from '../lib/sampleScorecards'
 import { createScorecardPdf } from '../utilities/createScorecardPdf'
 import type { Scorecard } from '../lib/computeScorecard'
@@ -15,7 +14,8 @@ function Score() {
     if (ticker.toUpperCase() === 'CRSP') {
       setScorecard(crspScorecard)
     } else {
-      setScorecard(computeScorecard(ticker))
+      // Placeholder until live scoring is implemented
+      setScorecard(null)
     }
   }, [ticker])
 
@@ -56,7 +56,7 @@ function Score() {
         {scorecard ? (
           <ScorecardRenderer scorecard={scorecard} actions={actions} />
         ) : (
-          <p>Scoring...</p>
+          <p className="text-slate-600">Scorecard coming soon.</p>
         )}
       </main>
     </section>


### PR DESCRIPTION
## Summary
- load the mock CRSP scorecard when the ticker is `CRSP`
- show a placeholder message for all other tickers

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844a7beaec8832abb05dbf28f08540b