### PR TITLE
Enable PDF export & add watchlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This project was bootstrapped with [Vite](https://vitejs.dev/) using the React + TypeScript template.
 Tailwind CSS is configured for styling, and React Router provides navigation.
 
+The Score page now supports PDF export and a persistent watchlist.
+
 ## Development
 
 ```bash
@@ -23,6 +25,11 @@ Ensure dependencies are installed with `npm install`, then run:
 ```bash
 npm run lint
 ```
+
+### Scorecard Watchlist
+
+Click the **Watchlist** button on any scorecard to save the ticker locally. View
+your saved tickers at `/watchlist`.
 
 The `dist` directory will contain the optimized site with compiled Tailwind utilities.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Quiz from './Quiz'
 import Summary from './Summary'
 import RisksSummary from './RisksSummary'
 import Score from './Score'
+import Watchlist from './Watchlist'
 import TrustFooter from './components/TrustFooter'
 
 function App() {
@@ -15,6 +16,7 @@ function App() {
         <Route path="/summary" element={<Summary />} />
         <Route path="/risks" element={<RisksSummary />} />
         <Route path="/score/:ticker" element={<Score />} />
+        <Route path="/watchlist" element={<Watchlist />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
       <TrustFooter />

--- a/src/Score.tsx
+++ b/src/Score.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, Link } from 'react-router-dom'
 import ScorecardRenderer from '../components/ScorecardRenderer'
 import { crspScorecard } from '../lib/sampleScorecards'
 import { createScorecardPdf } from '../utilities/createScorecardPdf'
 import type { Scorecard } from '../lib/computeScorecard'
+import useWatchlist from './useWatchlist'
 
 function Score() {
   const { ticker } = useParams<{ ticker: string }>()
   const [scorecard, setScorecard] = useState<Scorecard | null>(null)
+  const [, addToWatchlist] = useWatchlist()
 
   useEffect(() => {
     if (!ticker) return
@@ -32,13 +34,28 @@ function Score() {
   }
 
   function handleWatchlist() {
-    if (scorecard) console.log('add to watchlist', scorecard.ticker)
+    if (ticker) addToWatchlist(ticker.toUpperCase())
+  }
+
+  async function handleShare() {
+    try {
+      await navigator.clipboard.writeText(window.location.href)
+      alert('Link copied to clipboard!')
+    } catch (err) {
+      console.warn('Failed to copy link', err)
+    }
   }
 
   const actions = (
     <>
       <button className="btn-primary" onClick={handleDownload}>
         Download PDF
+      </button>
+      <button
+        className="bg-slate-200 text-slate-700 rounded-md px-4 py-3 hover:bg-slate-300"
+        onClick={handleShare}
+      >
+        Share Link
       </button>
       <button
         className="bg-slate-200 text-slate-700 rounded-md px-4 py-3 hover:bg-slate-300"
@@ -58,6 +75,11 @@ function Score() {
         ) : (
           <p className="text-slate-600">Scorecard coming soon.</p>
         )}
+        <div className="pt-4 text-center text-sm">
+          <Link to="/watchlist" className="text-primary-600 underline">
+            View Watchlist
+          </Link>
+        </div>
       </main>
     </section>
   )

--- a/src/Watchlist.tsx
+++ b/src/Watchlist.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom'
+import useWatchlist from './useWatchlist'
+
+function Watchlist() {
+  const [list, , remove] = useWatchlist()
+
+  return (
+    <section className="min-h-screen flex flex-col items-center justify-center bg-slate-50 text-slate-800 p-6">
+      <main className="max-w-md w-full space-y-6">
+        <h1 className="text-2xl font-bold text-center">Your Watchlist</h1>
+        {list.length === 0 ? (
+          <p className="text-center text-slate-600">No tickers saved yet.</p>
+        ) : (
+          <ul className="space-y-3">
+            {list.map((ticker) => (
+              <li key={ticker} className="flex justify-between items-center bg-white rounded-md shadow px-4 py-3">
+                <Link to={`/score/${ticker}`} className="text-primary-600 font-medium">
+                  {ticker}
+                </Link>
+                <button
+                  onClick={() => remove(ticker)}
+                  className="text-sm text-slate-500 hover:text-red-600"
+                >
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </section>
+  )
+}
+
+export default Watchlist

--- a/src/useWatchlist.ts
+++ b/src/useWatchlist.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react'
+
+const STORAGE_KEY = 'watchlist'
+
+export default function useWatchlist(): [string[], (t: string) => void, (t: string) => void] {
+  const [list, setList] = useState<string[]>(() => {
+    if (typeof window === 'undefined') return []
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      return stored ? (JSON.parse(stored) as string[]) : []
+    } catch (err) {
+      console.warn('Failed to parse watchlist', err)
+      return []
+    }
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(list))
+    } catch (err) {
+      console.warn('Failed to persist watchlist', err)
+    }
+  }, [list])
+
+  const add = (ticker: string) => {
+    setList((prev) => (prev.includes(ticker) ? prev : [...prev, ticker]))
+  }
+
+  const remove = (ticker: string) => {
+    setList((prev) => prev.filter((t) => t !== ticker))
+  }
+
+  return [list, add, remove]
+}


### PR DESCRIPTION
## Summary
- wire up scorecard PDF export
- add local watchlist utilities and page
- allow sharing link via clipboard
- document watchlist feature

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844a9210ffc832aa430a7fc1a919f6c