### PR TITLE
Implement dynamic scorecards

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project was bootstrapped with [Vite](https://vitejs.dev/) using the React + TypeScript template.
 Tailwind CSS is configured for styling, and React Router provides navigation.
 
-The Score page now supports PDF export and a persistent watchlist.
+The Score page now supports PDF export, a persistent watchlist, and dynamic scoring for any ticker.
 
 ## Development
 

--- a/src/Score.tsx
+++ b/src/Score.tsx
@@ -4,6 +4,7 @@ import ScorecardRenderer from '../components/ScorecardRenderer'
 import { crspScorecard } from '../lib/sampleScorecards'
 import { createScorecardPdf } from '../utilities/createScorecardPdf'
 import type { Scorecard } from '../lib/computeScorecard'
+import { computeScorecard } from '../lib/computeScorecard'
 import useWatchlist from './useWatchlist'
 
 function Score() {
@@ -16,8 +17,7 @@ function Score() {
     if (ticker.toUpperCase() === 'CRSP') {
       setScorecard(crspScorecard)
     } else {
-      // Placeholder until live scoring is implemented
-      setScorecard(null)
+      setScorecard(computeScorecard(ticker))
     }
   }, [ticker])
 


### PR DESCRIPTION
## Summary
- generate live scorecards for any ticker with `computeScorecard`
- document new dynamic scoring

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844ab33e410832a97b2bb1ba98254f8