### PR TITLE
Add ticker snapshot views

### DIFF
--- a/public/financials/AAPL.json
+++ b/public/financials/AAPL.json
@@ -1,0 +1,6 @@
+{
+  "ticker": "AAPL",
+  "price": 189.95,
+  "ebitda": "125.3B",
+  "marketCap": "2.9T"
+}

--- a/public/financials/CRSP.json
+++ b/public/financials/CRSP.json
@@ -1,0 +1,6 @@
+{
+  "ticker": "CRSP",
+  "price": 79.10,
+  "ebitda": "-1.1B",
+  "marketCap": "6.4B"
+}

--- a/public/financials/GOOGL.json
+++ b/public/financials/GOOGL.json
@@ -1,0 +1,6 @@
+{
+  "ticker": "GOOGL",
+  "price": 178.12,
+  "ebitda": "104.2B",
+  "marketCap": "2.0T"
+}

--- a/public/financials/MSFT.json
+++ b/public/financials/MSFT.json
@@ -1,0 +1,6 @@
+{
+  "ticker": "MSFT",
+  "price": 412.45,
+  "ebitda": "103.4B",
+  "marketCap": "3.1T"
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Summary from './Summary'
 import RisksSummary from './RisksSummary'
 import Score from './Score'
 import Watchlist from './Watchlist'
+import TickerInfo from './TickerInfo'
 import TrustFooter from './components/TrustFooter'
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
         <Route path="/summary" element={<Summary />} />
         <Route path="/risks" element={<RisksSummary />} />
         <Route path="/score/:ticker" element={<Score />} />
+        <Route path="/ticker/:ticker" element={<TickerInfo />} />
         <Route path="/watchlist" element={<Watchlist />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>

--- a/src/Score.tsx
+++ b/src/Score.tsx
@@ -70,6 +70,13 @@ function Score() {
     <section className="min-h-screen flex flex-col items-center justify-center bg-slate-50 text-slate-800 p-6">
       <main className="max-w-md w-full space-y-6 text-center">
         <h1 className="text-2xl font-bold">{ticker?.toUpperCase()} Scorecard</h1>
+        {ticker && (
+          <div className="text-sm">
+            <Link to={`/ticker/${ticker}`} className="text-primary-600 underline">
+              View Stock Snapshot
+            </Link>
+          </div>
+        )}
         {scorecard ? (
           <ScorecardRenderer scorecard={scorecard} actions={actions} />
         ) : (

--- a/src/TickerInfo.tsx
+++ b/src/TickerInfo.tsx
@@ -1,0 +1,48 @@
+import { useParams, Link } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+
+interface Metrics {
+  ticker: string
+  price: number
+  ebitda: string
+  marketCap: string
+}
+
+function TickerInfo() {
+  const { ticker } = useParams<{ ticker: string }>()
+  const [data, setData] = useState<Metrics | null>(null)
+
+  useEffect(() => {
+    if (!ticker) return
+    fetch(`/financials/${ticker.toUpperCase()}.json`)
+      .then((res) => res.json())
+      .then((json) => setData(json))
+      .catch(() => setData(null))
+  }, [ticker])
+
+  if (!ticker) return null
+
+  return (
+    <section className="min-h-screen flex flex-col items-center justify-center bg-slate-50 text-slate-800 p-6">
+      <main className="max-w-md w-full space-y-6 text-center">
+        <h1 className="text-2xl font-bold">{ticker.toUpperCase()} Snapshot</h1>
+        {data ? (
+          <div className="space-y-2">
+            <p>Stock Price: ${'{'}data.price{'}'}</p>
+            <p>EBITDA: {data.ebitda}</p>
+            <p>Market Cap: {data.marketCap}</p>
+          </div>
+        ) : (
+          <p className="text-slate-600">No data available.</p>
+        )}
+        <div className="pt-4 text-center text-sm">
+          <Link to={`/score/${ticker}`} className="text-primary-600 underline">
+            Back to Scorecard
+          </Link>
+        </div>
+      </main>
+    </section>
+  )
+}
+
+export default TickerInfo


### PR DESCRIPTION
## Summary
- create sample financial data JSON files
- add `TickerInfo` page to fetch EBITDA, stock price, etc
- wire new route for `/ticker/:ticker`
- link from Scorecard page to the snapshot

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844aceef808832a85209994a76ee660