### PR TITLE
Enhance stock snapshot UI

### DIFF
--- a/public/financials/AAPL.json
+++ b/public/financials/AAPL.json
@@ -2,5 +2,6 @@
   "ticker": "AAPL",
   "price": 189.95,
   "ebitda": "125.3B",
+  "ebitdaPeriod": "TTM",
   "marketCap": "2.9T"
 }

--- a/public/financials/CRSP.json
+++ b/public/financials/CRSP.json
@@ -2,5 +2,6 @@
   "ticker": "CRSP",
   "price": 79.10,
   "ebitda": "-1.1B",
+  "ebitdaPeriod": "TTM",
   "marketCap": "6.4B"
 }

--- a/public/financials/GOOGL.json
+++ b/public/financials/GOOGL.json
@@ -2,5 +2,6 @@
   "ticker": "GOOGL",
   "price": 178.12,
   "ebitda": "104.2B",
+  "ebitdaPeriod": "TTM",
   "marketCap": "2.0T"
 }

--- a/public/financials/MSFT.json
+++ b/public/financials/MSFT.json
@@ -2,5 +2,6 @@
   "ticker": "MSFT",
   "price": 412.45,
   "ebitda": "103.4B",
+  "ebitdaPeriod": "TTM",
   "marketCap": "3.1T"
 }

--- a/src/TickerInfo.tsx
+++ b/src/TickerInfo.tsx
@@ -5,6 +5,7 @@ interface Metrics {
   ticker: string
   price: number
   ebitda: string
+  ebitdaPeriod?: string
   marketCap: string
 }
 
@@ -23,20 +24,41 @@ function TickerInfo() {
   if (!ticker) return null
 
   return (
-    <section className="min-h-screen flex flex-col items-center justify-center bg-slate-50 text-slate-800 p-6">
-      <main className="max-w-md w-full space-y-6 text-center">
-        <h1 className="text-2xl font-bold">{ticker.toUpperCase()} Snapshot</h1>
+    <section className="min-h-screen flex flex-col items-center bg-slate-50 text-slate-800 p-6">
+      <main className="max-w-md w-full space-y-6">
+        <h1 className="text-3xl font-bold text-center">
+          {ticker.toUpperCase()} Snapshot
+        </h1>
         {data ? (
-          <div className="space-y-2">
-            <p>Stock Price: ${'{'}data.price{'}'}</p>
-            <p>EBITDA: {data.ebitda}</p>
-            <p>Market Cap: {data.marketCap}</p>
+          <div className="card space-y-4 text-left">
+            <div className="flex justify-between items-baseline">
+              <span className="font-medium">Stock Price</span>
+              <span className="font-mono text-lg">
+                {Intl.NumberFormat('en-US', {
+                  style: 'currency',
+                  currency: 'USD',
+                  maximumFractionDigits: 2,
+                }).format(data.price)}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="font-medium">EBITDA ({data.ebitdaPeriod || 'TTM'})</span>
+              <span className="font-mono">{data.ebitda}</span>
+            </div>
+            <p className="text-sm text-slate-600">
+              EBITDA represents earnings before interest, taxes, depreciation and
+              amortization for the trailing twelve months.
+            </p>
+            <div className="flex justify-between">
+              <span className="font-medium">Market Cap</span>
+              <span className="font-mono">{data.marketCap}</span>
+            </div>
           </div>
         ) : (
-          <p className="text-slate-600">No data available.</p>
+          <p className="text-slate-600 text-center">No data available.</p>
         )}
-        <div className="pt-4 text-center text-sm">
-          <Link to={`/score/${ticker}`} className="text-primary-600 underline">
+        <div className="pt-4 text-center">
+          <Link to={`/score/${ticker}`} className="btn-primary inline-block">
             Back to Scorecard
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- add trailing-twelve-month `ebitdaPeriod` to sample financials
- improve snapshot card layout and currency formatting

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844b0d113c8832abaf5cac383a2114d