### PR TITLE
Add last updated display for ticker info

### DIFF
--- a/public/financials/AAPL.json
+++ b/public/financials/AAPL.json
@@ -3,5 +3,6 @@
   "price": 189.95,
   "ebitda": "125.3B",
   "ebitdaPeriod": "TTM",
-  "marketCap": "2.9T"
+  "marketCap": "2.9T",
+  "lastUpdated": "2024-05-16T14:00:00Z"
 }

--- a/public/financials/CRSP.json
+++ b/public/financials/CRSP.json
@@ -3,5 +3,6 @@
   "price": 79.10,
   "ebitda": "-1.1B",
   "ebitdaPeriod": "TTM",
-  "marketCap": "6.4B"
+  "marketCap": "6.4B",
+  "lastUpdated": "2024-05-16T14:00:00Z"
 }

--- a/public/financials/GOOGL.json
+++ b/public/financials/GOOGL.json
@@ -3,5 +3,6 @@
   "price": 178.12,
   "ebitda": "104.2B",
   "ebitdaPeriod": "TTM",
-  "marketCap": "2.0T"
+  "marketCap": "2.0T",
+  "lastUpdated": "2024-05-16T14:00:00Z"
 }

--- a/public/financials/MSFT.json
+++ b/public/financials/MSFT.json
@@ -3,5 +3,6 @@
   "price": 412.45,
   "ebitda": "103.4B",
   "ebitdaPeriod": "TTM",
-  "marketCap": "3.1T"
+  "marketCap": "3.1T",
+  "lastUpdated": "2024-05-16T14:00:00Z"
 }

--- a/src/TickerInfo.tsx
+++ b/src/TickerInfo.tsx
@@ -7,6 +7,7 @@ interface Metrics {
   ebitda: string
   ebitdaPeriod?: string
   marketCap: string
+  lastUpdated?: string
 }
 
 function TickerInfo() {
@@ -53,6 +54,15 @@ function TickerInfo() {
               <span className="font-medium">Market Cap</span>
               <span className="font-mono">{data.marketCap}</span>
             </div>
+            {data.lastUpdated && (
+              <p className="text-right text-sm text-slate-500 pt-2">
+                Last updated{' '}
+                {new Date(data.lastUpdated).toLocaleString(undefined, {
+                  dateStyle: 'medium',
+                  timeStyle: 'short',
+                })}
+              </p>
+            )}
           </div>
         ) : (
           <p className="text-slate-600 text-center">No data available.</p>


### PR DESCRIPTION
## Summary
- track `lastUpdated` in each sample financials file
- show the last update time on the stock snapshot page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844b3edb3c0832aa23b556f523e45ee