### PR TITLE
Add EODHD API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Click the **Watchlist** button on any scorecard to save the ticker locally. View
 your saved tickers at `/watchlist`.
 
 The `dist` directory will contain the optimized site with compiled Tailwind utilities.
+## API Example
+
+Run `eodhd_api_example.py` to fetch sample data from the EODHD Fundamental Data, Insider Transactions, and Earnings Calendar APIs. Set an `EODHD_API_TOKEN` environment variable with your API key before running.
+
 
 ## License
 

--- a/eodhd_api_example.py
+++ b/eodhd_api_example.py
@@ -1,0 +1,39 @@
+import os
+import requests
+
+API_TOKEN = os.getenv("EODHD_API_TOKEN", "YOUR_API_TOKEN")
+
+
+def fetch_fundamental(ticker: str):
+    url = f"https://eodhd.com/api/fundamentals/{ticker}?api_token={API_TOKEN}&fmt=json"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_insider_transactions(ticker: str):
+    url = f"https://eodhd.com/api/insider-transactions?api_token={API_TOKEN}&ticker={ticker}&fmt=json"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_earnings_calendar(start: str, end: str):
+    url = (
+        f"https://eodhd.com/api/calendar/earnings?from={start}&to={end}"
+        f"&api_token={API_TOKEN}&fmt=json"
+    )
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+if __name__ == "__main__":
+    ticker = "AAPL.US"
+    fundamental = fetch_fundamental(ticker)
+    insider = fetch_insider_transactions(ticker)
+    earnings = fetch_earnings_calendar("2018-12-02", "2018-12-06")
+
+    print("Fundamental data:\n", fundamental)
+    print("Insider transactions:\n", insider)
+    print("Earnings calendar:\n", earnings)


### PR DESCRIPTION
## Summary
- add a sample Python script showing how to access EODHD Fundamental Data, Insider Transactions, and Earnings Calendar APIs
- document new script in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6844b578d88c832ab0cfbcb9d9ca5327