### PR TITLE
Fix Vercel build directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "pnpm run build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
## Summary
- configure Vercel to find `.next` after building

## Testing
- `pnpm install`
- `pnpm run build`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844fbc9e16c832a9f41f059df724c51