### PR TITLE
Fix build output path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@
 /.next/
 /out/
 
-# custom dist directory
-/dist/
 
 # production
 /build

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  distDir: "dist",
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
## Summary
- revert custom build `dist` directory
- clean up `.gitignore`

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_6845b289f2b4832a8a29edcd4a0039d6